### PR TITLE
query limits

### DIFF
--- a/models/staging/stg_green_tripdata.sql
+++ b/models/staging/stg_green_tripdata.sql
@@ -44,6 +44,6 @@ where rn = 1
 -- dbt build --m <model.sql> --var 'is_test_run: false'
 {% if var('is_test_run', default=true) %}
 
-    limit 100
+   --limit 100 
 
 {% endif %}

--- a/models/staging/stg_yellow_tripdata.sql
+++ b/models/staging/stg_yellow_tripdata.sql
@@ -43,6 +43,6 @@ where rn = 1
 -- dbt build --m <model.sql> --var 'is_test_run: false'
 {% if var('is_test_run', default=true) %}
 
-    limit 100
+    --limit 100
     
 {% endif %}


### PR DESCRIPTION
commented query limits